### PR TITLE
feat: add continuous deployment workflow to publish JAR on pull reque…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,40 @@
+name: CD - Publish JAR
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  publish-jar:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build JAR
+        run: mvn -B package --file schiffe-versenken/pom.xml
+
+      - name: Publish JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: schiffe-versenken-jar-pr-${{ github.event.pull_request.number }}
+          path: schiffe-versenken/target/*.jar
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate publishing JAR artifacts when pull requests are merged into the `main` branch. The workflow ensures that the latest build is available as an artifact for each merged PR.

**Continuous Deployment Workflow:**

* Added `.github/workflows/cd.yml` to trigger on merged pull requests to `main`, building the JAR using Maven with JDK 25 and uploading it as an artifact with a 90-day retention period.…st merge