### PR TITLE
feat: update CD workflow to publish JAR as GitHub Release asset on PR…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish-jar:
@@ -31,10 +31,12 @@ jobs:
       - name: Build JAR
         run: mvn -B package --file schiffe-versenken/pom.xml
 
-      - name: Publish JAR artifact
-        uses: actions/upload-artifact@v4
+      - name: Publish JAR as GitHub Release asset
+        uses: softprops/action-gh-release@v2
         with:
-          name: schiffe-versenken-jar-pr-${{ github.event.pull_request.number }}
-          path: schiffe-versenken/target/*.jar
-          if-no-files-found: error
-          retention-days: 90
+          tag_name: pr-${{ github.event.pull_request.number }}-merged
+          name: PR #${{ github.event.pull_request.number }} merged into main
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          generate_release_notes: true
+          files: schiffe-versenken/target/*.jar
+          fail_on_unmatched_files: true


### PR DESCRIPTION
This pull request updates the continuous deployment workflow to improve how JAR artifacts are published when a pull request is merged. Instead of uploading the JAR as a build artifact, the workflow now attaches it directly to a GitHub Release, making it easier to access and manage release assets.

**Workflow permissions:**

* Changed the `contents` permission from `read` to `write` in `.github/workflows/cd.yml` to allow the workflow to create GitHub Releases.

**Artifact publishing improvements:**

* Replaced the step that uploaded the JAR as a build artifact with a new step that publishes the JAR as a GitHub Release asset using `softprops/action-gh-release@v2`. The release is automatically created with a tag and release notes when a pull request is merged.… merge