### PR TITLE
Enhance CI/CD workflows for version bump and JAR publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,15 +28,26 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Read project version
+        id: project_version
+        run: echo "value=$(mvn -q -DforceStdout -f schiffe-versenken/pom.xml help:evaluate -Dexpression=project.version)" >> $GITHUB_OUTPUT
+
       - name: Build JAR
         run: mvn -B package --file schiffe-versenken/pom.xml
+
+      - name: Prepare versioned release asset
+        env:
+          PROJECT_VERSION: ${{ steps.project_version.outputs.value }}
+        run: |
+          RUNNABLE_JAR=$(ls schiffe-versenken/target/*-runnable.jar | head -n 1)
+          cp "$RUNNABLE_JAR" "schiffe-versenken/target/schiffe-versenken-${PROJECT_VERSION}.jar"
 
       - name: Publish JAR as GitHub Release asset
         uses: softprops/action-gh-release@v2
         with:
           tag_name: pr-${{ github.event.pull_request.number }}-merged
-          name: PR #${{ github.event.pull_request.number }} merged into main
+          name: PR #${{ github.event.pull_request.number }} merged into main - v${{ steps.project_version.outputs.value }}
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           generate_release_notes: true
-          files: schiffe-versenken/target/*.jar
+          files: schiffe-versenken/target/schiffe-versenken-${{ steps.project_version.outputs.value }}.jar
           fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Ensure version was bumped for PRs to main
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        BASE_REF="${{ github.event.pull_request.base.ref }}"
+        git fetch --no-tags --depth=1 origin "${BASE_REF}"
+
+        extract_version() {
+          sed -n '0,/<version>/s:.*<version>\([^<]*\)</version>.*:\1:p'
+        }
+
+        BASE_VERSION=$(git show "origin/${BASE_REF}:schiffe-versenken/pom.xml" | extract_version)
+        HEAD_VERSION=$(extract_version < schiffe-versenken/pom.xml)
+
+        if [ -z "${BASE_VERSION}" ] || [ -z "${HEAD_VERSION}" ]; then
+          echo "Could not read project version from pom.xml"
+          exit 1
+        fi
+
+        if [ "${BASE_VERSION}" = "${HEAD_VERSION}" ]; then
+          echo "Version must be changed before merge. Current PR version: ${HEAD_VERSION}"
+          exit 1
+        fi
+
+        echo "Version bump detected: ${BASE_VERSION} -> ${HEAD_VERSION}"
     - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/schiffe-versenken/pom.xml
+++ b/schiffe-versenken/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>hsaa.sose26</groupId>
   <artifactId>schiffe-versenken</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.1</version>
   <name>schiffe-versenken</name>
   <url>http://example.com</url>
 
@@ -58,6 +58,31 @@
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
         </configuration>
+      </plugin>
+
+      <!-- Creates an executable jar with all runtime dependencies included. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>runnable</shadedClassifierName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>AppStartup</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
This pull request introduces improvements to the build, release, and CI/CD processes for the project, focusing on version management and packaging. The main changes ensure that version bumps are enforced for pull requests, a runnable (fat) JAR is produced during packaging, and release assets are named according to the project version.

**Continuous Integration and Release Process Improvements:**

* Enforced version bump in pull requests to `main` by adding a CI step in `.github/workflows/ci.yml` that compares the project version in `pom.xml` between the base and head branches, failing the build if the version hasn't changed.
* Updated the release workflow in `.github/workflows/cd.yml` to extract the project version from `pom.xml` and use it for naming the release asset and release name, ensuring versioned artifacts are published.

**Build System Enhancements:**

* Added the `maven-shade-plugin` configuration to `schiffe-versenken/pom.xml` to produce an executable JAR (`*-runnable.jar`) with all dependencies included, specifying `AppStartup` as the main class.
* Updated the project version in `schiffe-versenken/pom.xml` from `1.0-SNAPSHOT` to `1.0.1` to reflect a new release.

**Development Environment:**

* Changed the VSCode Java build configuration update mode to `automatic` in `.vscode/settings.json` for a smoother developer experience.