### PR TITLE
Update JAR naming convention and version in CI/CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,14 +40,14 @@ jobs:
           PROJECT_VERSION: ${{ steps.project_version.outputs.value }}
         run: |
           RUNNABLE_JAR=$(ls schiffe-versenken/target/*-runnable.jar | head -n 1)
-          cp "$RUNNABLE_JAR" "schiffe-versenken/target/schiffe-versenken-${PROJECT_VERSION}.jar"
+          cp "$RUNNABLE_JAR" "schiffe-versenken/target/ProgPragSoSe26-schiffe-versenken-${PROJECT_VERSION}.jar"
 
       - name: Publish JAR as GitHub Release asset
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: pr-${{ github.event.pull_request.number }}-merged
-          name: PR #${{ github.event.pull_request.number }} merged into main - v${{ steps.project_version.outputs.value }}
+          tag_name: v${{ steps.project_version.outputs.value }}
+          name: v${{ steps.project_version.outputs.value }}
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           generate_release_notes: true
-          files: schiffe-versenken/target/schiffe-versenken-${{ steps.project_version.outputs.value }}.jar
+          files: schiffe-versenken/target/ProgPragSoSe26-schiffe-versenken-${{ steps.project_version.outputs.value }}.jar
           fail_on_unmatched_files: true

--- a/schiffe-versenken/pom.xml
+++ b/schiffe-versenken/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>hsaa.sose26</groupId>
   <artifactId>schiffe-versenken</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>schiffe-versenken</name>
   <url>http://example.com</url>
 


### PR DESCRIPTION
This pull request updates the release workflow and project versioning for the `schiffe-versenken` project. The most important changes are:

Release workflow improvements:
* The GitHub Actions workflow now names the release JAR file as `ProgPragSoSe26-schiffe-versenken-${PROJECT_VERSION}.jar` instead of the previous format, ensuring more consistent and descriptive artifact naming.
* The GitHub Release tag and name now use the version number (e.g., `v1.0.2`) instead of a pull request-based naming scheme, making releases easier to track.

Version update:
* The project version in `pom.xml` is incremented from `1.0.1` to `1.0.2` to reflect the new release.